### PR TITLE
Fixed error when loading project file when only KAP layer is present

### DIFF
--- a/maproom/app_framework/loader.py
+++ b/maproom/app_framework/loader.py
@@ -27,6 +27,9 @@ class FileGuess:
         self._zipfile = None
         self._filesystem_path = None
 
+    def __str__(self):
+        return f"FileGuess: {self.uri} is_binary={self.is_binary} is_zipfile={self.is_zipfile}"
+
     @property
     def sample_data(self):
         if self._sample_data is None:

--- a/maproom/loaders/project.py
+++ b/maproom/loaders/project.py
@@ -14,9 +14,8 @@ WHITESPACE_PATTERN = re.compile("\s+")
 
 
 def identify_loader(file_guess):
-    if file_guess.is_binary:
-        if file_guess.is_zipfile and file_guess.zipfile_contains("pre json data"):
-            return dict(mime="application/x-maproom-project-zip", loader=ZipProjectLoader())
+    if file_guess.is_zipfile and file_guess.zipfile_contains("pre json data"):
+        return dict(mime="application/x-maproom-project-zip", loader=ZipProjectLoader())
     else:
         if file_guess.sample_data.startswith(b"# -*- MapRoom project file -*-"):
             return dict(mime="application/x-maproom-project-json", loader=ProjectLoader())


### PR DESCRIPTION
Removed check for binary file (which was incorrectly marking the zipfile as a text file)